### PR TITLE
smårettinger i RnR meldingstruktur

### DIFF
--- a/src/main/kotlin/no/nav/hjelpemidler/joark/service/JoarkDataSink.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/joark/service/JoarkDataSink.kt
@@ -120,9 +120,10 @@ internal data class SoknadData(
     internal fun toJson(joarkRef: String): String {
         return JsonMessage("{}", MessageProblems("")).also {
             it["soknadId"] = this.soknadId
-            it["@event_name"] = "SøknadArkivert"
-            it["@opprettet"] = LocalDateTime.now()
-            it["fodselNrBruker"] = this.fnrBruker
+            it["eventName"] = "hm-SøknadArkivert"
+            it["opprettet"] = LocalDateTime.now()
+            it["fodselNrBruker"] = this.fnrBruker // @deprecated
+            it["fnrBruker"] = this.fnrBruker
             it["joarkRef"] = joarkRef
             it["eventId"] = UUID.randomUUID()
         }.toJson()


### PR DESCRIPTION
Bakoverkompatible endringar så vidt eg kan sjå. `hm-oppgave-sink` brukar ikkje eventName. Beholder fodselNrBruker fram til oppgave-sink byttar.