### PR TITLE
New method for rapid messageformat validation error handling

### DIFF
--- a/src/main/kotlin/no/nav/hjelpemidler/joark/service/JoarkDataSink.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/joark/service/JoarkDataSink.kt
@@ -43,7 +43,12 @@ internal class JoarkDataSink(
 
     init {
         River(rapidsConnection).apply {
-            validate { it.demandValue("eventName", "hm-Søknad") }
+            validate { it.demandValue("eventName","hm-Søknad") }
+            validate { it.requireKey("fodselNrBruker", "navnBruker", "soknad", "soknadId") }
+        }.register(this)
+
+        River(rapidsConnection).apply {
+            validate { it.demandValue("eventName","hm-SøknadGodkjentAvBruker") }
             validate { it.requireKey("fodselNrBruker", "navnBruker", "soknad", "soknadId") }
         }.register(this)
     }

--- a/src/main/kotlin/no/nav/hjelpemidler/joark/service/JoarkDataSink.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/joark/service/JoarkDataSink.kt
@@ -30,8 +30,7 @@ internal class JoarkDataSink(
     rapidsConnection: RapidsConnection,
     private val pdfClient: PdfClient,
     private val joarkClient: JoarkClient
-) :
-    River.PacketListener {
+) : PacketListenerWithOnError {
 
     companion object {
         private val objectMapper = jacksonObjectMapper()
@@ -44,6 +43,7 @@ internal class JoarkDataSink(
 
     init {
         River(rapidsConnection).apply {
+            validate { it.demandValue("eventName", "hm-Søknad") }
             validate { it.requireKey("fodselNrBruker", "navnBruker", "soknad", "soknadId") }
         }.register(this)
     }

--- a/src/main/kotlin/no/nav/hjelpemidler/joark/service/JoarkDataSink.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/joark/service/JoarkDataSink.kt
@@ -43,12 +43,12 @@ internal class JoarkDataSink(
 
     init {
         River(rapidsConnection).apply {
-            validate { it.demandValue("eventName","hm-Søknad") }
+            validate { it.demandValue("eventName", "hm-Søknad") }
             validate { it.requireKey("fodselNrBruker", "navnBruker", "soknad", "soknadId") }
         }.register(this)
 
         River(rapidsConnection).apply {
-            validate { it.demandValue("eventName","hm-SøknadGodkjentAvBruker") }
+            validate { it.demandValue("eventName", "hm-SøknadGodkjentAvBruker") }
             validate { it.requireKey("fodselNrBruker", "navnBruker", "soknad", "soknadId") }
         }.register(this)
     }

--- a/src/main/kotlin/no/nav/hjelpemidler/joark/service/PacketListenerWithOnError.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/joark/service/PacketListenerWithOnError.kt
@@ -1,0 +1,17 @@
+package no.nav.hjelpemidler.joark.service
+
+import mu.KotlinLogging
+import no.nav.helse.rapids_rivers.MessageProblems
+import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.helse.rapids_rivers.River
+
+private val sikkerlogg = KotlinLogging.logger("tjenestekall")
+
+class RiverRequiredKeyMissingException(msg: String) : Exception(msg)
+
+interface PacketListenerWithOnError : River.PacketListener {
+    override fun onError(problems: MessageProblems, context: RapidsConnection.MessageContext) {
+        sikkerlogg.info("River required keys had problems in parsing message from rapid: ${problems.toExtendedReport()}")
+        throw RiverRequiredKeyMissingException("River required keys had problems in parsing message from rapid, see Kibana index tjenestekall-* (sikkerlogg) for details")
+    }
+}


### PR DESCRIPTION
Vi har demandValue for å kvalifisere at noe er ment for en gitt river, og requireKey for verdier vi er avhengige av at eksisterer for å kunne prosessere meldingen. Videre har vi en onError-funksjon implementert som logger problemene med en melding hvis den har passert demandValue men har feilet på et eller flere requireKey sjekker. Videre vil onError kaste en exception og stoppe opp prosessering slik at vi blir nødt å fikse problemet før meldingen kan passere (dermed mister vi ingenting mellom stoler). Før-situasjonen der demandValue var brukt var at vi stille ignorerte meldinger.

Eksempel: noen endrer meldingsformat på vei ut av hm-soknadsbehandling uten at hm-ditt-nav først er lansert med støtte for det nye formatet. Da vil hm-ditt-nav gå i en feil-loop slik at vi merker feilen og kan fikse den uten at vi mister meldinger. Da vil den plukke opp alt den skulle gjort etter problemet er fikset. Dette lar oss også gjøre slike ting med vilje. Ødelegge prosessering up-stream og se hvor ting feiler down-stream. Mindre viktig å fikse R&R ting i korrekt rekkefølge.