### PR TITLE
fjern kompliserende coroutines

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -9,7 +9,7 @@ on:
       - "CODEOWNERS"
     branches:
       - main
-      - bytte
+      - fjern-coroutines
 
 jobs:
   build:

--- a/src/main/kotlin/no/nav/hjelpemidler/joark/service/barnebriller/ResendJournalpostBarnebriller.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/joark/service/barnebriller/ResendJournalpostBarnebriller.kt
@@ -1,10 +1,5 @@
 package no.nav.hjelpemidler.joark.service.barnebriller
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 import mu.KotlinLogging
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
@@ -12,13 +7,10 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import no.nav.helse.rapids_rivers.asLocalDate
 import no.nav.helse.rapids_rivers.asLocalDateTime
-import no.nav.hjelpemidler.joark.dokarkiv.models.OpprettJournalpostResponse
 import no.nav.hjelpemidler.joark.service.AsyncPacketListener
 import no.nav.hjelpemidler.joark.service.JournalpostService
-import kotlin.coroutines.cancellation.CancellationException
 
 private val log = KotlinLogging.logger {}
-private val secureLog = KotlinLogging.logger("tjenestekall")
 
 class ResendJournalpostBarnebriller(
     rapidsConnection: RapidsConnection,
@@ -65,74 +57,49 @@ class ResendJournalpostBarnebriller(
     private val JsonMessage.beløp get() = this["beløp"].decimalValue()
 
     override suspend fun onPacketAsync(packet: JsonMessage, context: MessageContext) {
-        coroutineScope {
-            launch {
-                val data = JournalpostBarnebrillevedtakData(
-                    fnr = packet.fnr,
-                    brukersNavn = packet.brukersNavn,
-                    orgnr = packet.orgnr,
-                    orgNavn = packet.orgNavn,
-                    orgAdresse = packet.orgAdresse,
-                    sakId = packet.sakId,
-                    navnAvsender = packet.navnAvsender,
-                    brilleseddel = packet.brilleseddel,
-                    opprettet = packet.opprettet,
-                    bestillingsdato = packet.bestillingsdato,
-                    bestillingsår = packet.bestillingsdato.year,
-                    bestillingsreferanse = packet.bestillingsreferanse,
-                    satsBeskrivelse = packet.satsBeskrivelse,
-                    satsBeløp = packet.satsBeløp,
-                    beløp = packet.beløp
-                )
-                log.info { "Sak til rejournalføring barnebriller mottatt, sakId: ${data.sakId}" }
-                val fysiskDokument = journalpostService.genererPdf(data)
-                val journalpost = journalpostService.opprettInngåendeJournalpost(
-                    fnrAvsender = data.fnr,
-                    dokumenttype = data.dokumenttype,
-                    forsøkFerdigstill = true,
-                ) {
-                    dokument(fysiskDokument = fysiskDokument)
-                    optiker(data.sakId)
-                    eksternReferanseId = "RE_${data.sakId}BARNEBRILLEAPI"
-                    datoMottatt = packet.opprettet
-                }
-                forward(journalpost, data, context)
-            }
-        }
-    }
+        val data = JournalpostBarnebrillevedtakData(
+            fnr = packet.fnr,
+            brukersNavn = packet.brukersNavn,
+            orgnr = packet.orgnr,
+            orgNavn = packet.orgNavn,
+            orgAdresse = packet.orgAdresse,
+            sakId = packet.sakId,
+            navnAvsender = packet.navnAvsender,
+            brilleseddel = packet.brilleseddel,
+            opprettet = packet.opprettet,
+            bestillingsdato = packet.bestillingsdato,
+            bestillingsår = packet.bestillingsdato.year,
+            bestillingsreferanse = packet.bestillingsreferanse,
+            satsBeskrivelse = packet.satsBeskrivelse,
+            satsBeløp = packet.satsBeløp,
+            beløp = packet.beløp
+        )
+        log.info { "Sak til rejournalføring barnebriller mottatt, sakId: ${data.sakId}" }
 
-    private fun CoroutineScope.forward(
-        journalpost: OpprettJournalpostResponse,
-        data: JournalpostBarnebrillevedtakData,
-        context: MessageContext,
-    ) {
-        val fnr = data.fnr
-        launch(Dispatchers.IO + SupervisorJob()) {
+        try {
+            val fysiskDokument = journalpostService.genererPdf(data)
+            val journalpost = journalpostService.opprettInngåendeJournalpost(
+                fnrAvsender = data.fnr,
+                dokumenttype = data.dokumenttype,
+                forsøkFerdigstill = true,
+            ) {
+                dokument(fysiskDokument = fysiskDokument)
+                optiker(data.sakId)
+                eksternReferanseId = "RE_${data.sakId}BARNEBRILLEAPI"
+                datoMottatt = packet.opprettet
+            }
+
             context.publish(
-                fnr,
+                data.fnr,
                 data.toJson(
                     journalpost.journalpostId,
                     journalpost.dokumenter?.mapNotNull { it.dokumentInfoId } ?: listOf(),
                     "hm-opprettetOgFerdigstiltBarnebrillerJournalpost",
-                )
-            )
-        }.invokeOnCompletion {
-            val sakId = data.sakId
-            when (it) {
-                null -> {
-                    log.info {
-                        "Opprettet og ferdigstilte journalpost for barnebriller i joark for sakId: $sakId"
-                    }
-                    secureLog.info {
-                        "Opprettet og ferdigstilte journalpost for barnebriller for sakId: $sakId, fnr: $fnr"
-                    }
-                }
-
-                is CancellationException -> log.warn(it) { "Cancelled" }
-                else -> log.error(it) {
-                    "Kunne ikke opprette og ferdigstille journalpost for barnebriller, sakId: $sakId"
-                }
-            }
+                ))
+            log.info { "Opprettet og ferdigstilte journalpost for barnebriller i joark for sakId: ${data.sakId}" }
+        } catch (e: Throwable) {
+            log.error(e) { "Kunne ikke opprette og ferdigstille journalpost for barnebriller, sakId: ${data.sakId}" }
+            throw e
         }
     }
 }

--- a/src/test/kotlin/no/nav/hjelpemidler/joark/service/hotsak/SakOpprettetOpprettOgFerdigstillJournalpostTest.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/joark/service/hotsak/SakOpprettetOpprettOgFerdigstillJournalpostTest.kt
@@ -40,7 +40,7 @@ class SakOpprettetOpprettOgFerdigstillJournalpostTest : TestSupport() {
         sendTestMessage(
             "eventName" to "hm-sakOpprettet",
             "soknadId" to UUID.randomUUID(),
-            "soknadJson" to jsonMapper.createObjectNode(),
+            "soknadJson" to jsonMapper.createObjectNode().also { it.put("behovsmeldingType", "SØKNAD") },
             "soknadGjelder" to "test",
             "sakId" to sakId,
             "fnrBruker" to fnrBruker,


### PR DESCRIPTION
Appen er allerede async via Kafka, dessuten er trafikken så begrenset og ikke så tidskritisk at det ikke er behov for å ha kompliserende coroutines-kode. Med fire-and-forget coroutines så er det også en sjangse for at appen avsluttes før en coroutine har fullført. Som kan føre til feil der events blir lest, men ikke ferdig behandlet.